### PR TITLE
Feature/epic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ A full-featured, test-driven project and task management API inspired by Jira. T
 
 - Role-based access control (Admin, Regular User)
 - Authentication via JWT
-- Projects with ownership and members
-- Tasks with status updates, labels, and filters
+- Projects, Epics and Tasks for hierarchical work organization
 - Modular architecture for maintainability and scalability
 - Full integration test coverage
 - Isolated environment setup for testing
@@ -39,9 +38,10 @@ The Mailer is its own dedicated module responsible for sending and managing all 
 - Project Invitations – Sends invite links via email and automatically creates a ProjectUser record with permissions upon acceptance
 - Password Reset – Allows users to request a reset token and update their password securely.
 
-### Projects & ProjectUsers
+### Projects, Epics & ProjectUsers
 
-- Create projects (with optional tasks)
+- Create projects
+- Epics: Introduced as an intermediate organizational layer between Projects and Tasks. Epics help group related tasks under a single, larger objective within a project.
 - Automatically assign project to Project User
 - Designed for full CRUD of project users
 - ProjectUser module serves as the canonical source for project membership and roles to enable consistent permissions enforcement
@@ -226,8 +226,6 @@ npm run enter:test
 ```bash
 npm run enter:test -- filename
 ```
-
-> All tests pass and run successfully. However, you may notice duplicate logs or memory issues during testing. This appears to be related to the test setup (possibly multiple app instances being created). It does not affect real usage (e.g., Postman).
 
 ---
 

--- a/folder-structure.txt
+++ b/folder-structure.txt
@@ -20,6 +20,7 @@
 ./test/rest
 ./test/rest/project.integration-spec.ts
 ./test/rest/project-permissions.integration-spec.ts
+./test/rest/epic.integration-spec.ts
 ./test/rest/auth.integration-spec.ts
 ./test/rest/tasks.integration-spec.ts
 ./test/rest/app.integration-spec.ts
@@ -172,6 +173,7 @@
 ./src/common/dtos
 ./src/common/dtos/params
 ./src/common/dtos/params/token.params.ts
+./src/common/dtos/params/epicId.params.ts
 ./src/common/dtos/params/taskId.params.ts
 ./src/common/dtos/params/projectId.params.ts
 ./src/password-reset
@@ -213,3 +215,16 @@
 ./src/users/dtos/create-user.dto.ts
 ./src/users/role.enum.ts
 ./src/app.controller.ts
+./src/epics
+./src/epics/types
+./src/epics/epics.controller.ts
+./src/epics/epics.module.ts
+./src/epics/epics.service.ts
+./src/epics/epics.entity.ts
+./src/epics/enums
+./src/epics/enums/epic-priority.enum.ts
+./src/epics/enums/epic-status.enum.ts
+./src/epics/dtos
+./src/epics/dtos/epic.dto.ts
+./src/epics/dtos/create-epic.dto.ts
+./src/epics/dtos/update-epic.dto.ts

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,6 +37,8 @@ import { EmailVerificationModule } from './email-verification/email-verification
 import { EmailVerification } from './email-verification/email-verification.entity';
 import { PasswordResetModule } from './password-reset/password-reset.module';
 import { PasswordReset } from './password-reset/password-reset.entity';
+import { EpicModule } from './epics/epics.module';
+import { Epic } from './epics/epics.entity';
 
 @Module({
   imports: [
@@ -60,6 +62,7 @@ import { PasswordReset } from './password-reset/password-reset.entity';
           User,
           TaskLabel,
           Project,
+          Epic,
           ProjectUser,
           ProjectUserInvite,
           ProjectPermission,
@@ -91,8 +94,14 @@ import { PasswordReset } from './password-reset/password-reset.entity';
         module: ProjectsModule,
         children: [
           {
-            path: ':projectId/tasks',
-            module: TasksModule,
+            path: ':projectId/epics',
+            module: EpicModule,
+            children: [
+              {
+                path: ':epicId/tasks',
+                module: TasksModule,
+              },
+            ],
           },
           {
             path: ':projectId/invite',
@@ -111,6 +120,7 @@ import { PasswordReset } from './password-reset/password-reset.entity';
     CacheModule.register(),
     EmailVerificationModule,
     PasswordResetModule,
+    EpicModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/dtos/params/epicId.params.ts
+++ b/src/common/dtos/params/epicId.params.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class EpicIdParams {
+  @IsNotEmpty()
+  @IsUUID()
+  @IsString()
+  epicId!: string;
+}

--- a/src/config/project-permissions.config.ts
+++ b/src/config/project-permissions.config.ts
@@ -8,6 +8,12 @@ export const defaultProjectPermissions: ProjectPermissionMap = deepFreeze({
       update: true,
       delete: true,
     },
+    epics: {
+      read: true,
+      create: true,
+      update: true,
+      delete: true,
+    },
     tasks: {
       read: true,
       create: true,
@@ -34,6 +40,12 @@ export const defaultProjectPermissions: ProjectPermissionMap = deepFreeze({
       read: true,
       update: true,
     },
+    epics: {
+      read: true,
+      create: true,
+      update: true,
+      delete: true,
+    },
     tasks: {
       read: true,
       create: true,
@@ -45,6 +57,9 @@ export const defaultProjectPermissions: ProjectPermissionMap = deepFreeze({
   },
   USER: {
     projects: {
+      read: true,
+    },
+    epics: {
       read: true,
     },
     tasks: {

--- a/src/epics/dtos/create-epic.dto.ts
+++ b/src/epics/dtos/create-epic.dto.ts
@@ -1,0 +1,53 @@
+import {
+  IsBoolean,
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+import { EpicStatus } from '../enums/epic-status.enum';
+import { EpicPriority } from '../enums/epic-priority.enum';
+import { Type } from 'class-transformer';
+
+export class CreateEpicDto {
+  @IsNotEmpty()
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsEnum(EpicStatus)
+  status?: EpicStatus;
+
+  @IsOptional()
+  @IsEnum(EpicPriority)
+  priority?: EpicPriority;
+
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  startDate?: Date;
+
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  dueDate?: Date;
+
+  @IsOptional()
+  @IsString()
+  @IsUUID()
+  ownerId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  archived?: boolean;
+
+  @IsOptional()
+  @IsString()
+  color?: string;
+}

--- a/src/epics/dtos/epic.dto.ts
+++ b/src/epics/dtos/epic.dto.ts
@@ -1,0 +1,51 @@
+import { Exclude, Expose } from 'class-transformer';
+import { IsBoolean, IsDate, IsEnum, IsString, IsUUID } from 'class-validator';
+import { EpicStatus } from '../enums/epic-status.enum';
+import { EpicPriority } from '../enums/epic-priority.enum';
+
+@Exclude()
+export class EpicDto {
+  @Expose()
+  @IsUUID()
+  id!: string;
+
+  @Expose()
+  @IsString()
+  name!: string;
+
+  @Expose()
+  @IsUUID()
+  projectId!: string;
+
+  @Expose()
+  @IsString()
+  description?: string;
+
+  @Expose()
+  @IsEnum(EpicStatus)
+  status?: EpicStatus;
+
+  @Expose()
+  @IsEnum(EpicPriority)
+  priority!: EpicPriority;
+
+  @Expose()
+  @IsBoolean()
+  archived!: boolean;
+
+  @Expose()
+  @IsDate()
+  startDate?: Date;
+
+  @Expose()
+  @IsDate()
+  dueDate?: Date;
+
+  @Expose()
+  @IsUUID()
+  ownerId!: string;
+
+  @Expose()
+  @IsString()
+  color?: string;
+}

--- a/src/epics/dtos/update-epic.dto.ts
+++ b/src/epics/dtos/update-epic.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateEpicDto } from './create-epic.dto';
+
+export class UpdateEpicDto extends PartialType(CreateEpicDto) {}

--- a/src/epics/enums/epic-priority.enum.ts
+++ b/src/epics/enums/epic-priority.enum.ts
@@ -1,0 +1,6 @@
+export enum EpicPriority {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL',
+}

--- a/src/epics/enums/epic-status.enum.ts
+++ b/src/epics/enums/epic-status.enum.ts
@@ -1,0 +1,6 @@
+export enum EpicStatus {
+  TODO = 'TODO',
+  IN_PROGRESS = 'IN_PROGRESS',
+  DONE = 'DONE',
+  BLOCKED = 'BLOCKED',
+}

--- a/src/epics/epics.controller.ts
+++ b/src/epics/epics.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { ProjectIdParams } from 'src/common/dtos/params/projectId.params';
+import { CurrentUserId } from 'src/users/decorators/current-user-id.decorator';
+import { EpicService } from './epics.service';
+import { EpicDto } from './dtos/epic.dto';
+import { plainToInstance } from 'class-transformer';
+import { EpicIdParams } from 'src/common/dtos/params/epicId.params';
+import { transformToDto } from 'src/utils/transform';
+import { CreateEpicDto } from './dtos/create-epic.dto';
+import { UpdateEpicDto } from './dtos/update-epic.dto';
+import { Resource } from 'src/project-permissions/enums/resource.enum';
+import { Resources } from 'src/project-permissions/decorators/resource.decorator';
+
+@Controller()
+@Resources(Resource.EPIC)
+export class EpicController {
+  constructor(private readonly epicService: EpicService) {}
+  @Get()
+  async getAll(
+    @CurrentUserId() _: string,
+    @Param() { projectId }: ProjectIdParams,
+  ): Promise<EpicDto[]> {
+    const epics = await this.epicService.getAllEpics(projectId);
+    return plainToInstance(EpicDto, epics, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  @Get(':epicId')
+  async getOne(
+    @CurrentUserId() _: string,
+    @Param() { projectId }: ProjectIdParams,
+    @Param() { epicId }: EpicIdParams,
+  ): Promise<EpicDto> {
+    const epic = await this.epicService.getOneEpic(projectId, epicId);
+    return transformToDto(EpicDto, epic);
+  }
+
+  @Post()
+  async create(
+    @CurrentUserId() userId: string,
+    @Param() { projectId }: ProjectIdParams,
+    @Body() createEpicDto: CreateEpicDto,
+  ): Promise<EpicDto> {
+    const epic = await this.epicService.createEpic(
+      userId,
+      projectId,
+      createEpicDto,
+    );
+    return transformToDto(EpicDto, epic);
+  }
+
+  @Patch(':epicId')
+  async update(
+    @CurrentUserId() _: string,
+    @Param() { projectId }: ProjectIdParams,
+    @Param() { epicId }: EpicIdParams,
+    @Body() updateEpicDto: UpdateEpicDto,
+  ): Promise<EpicDto> {
+    const epic = await this.epicService.updateEpic(
+      updateEpicDto,
+      projectId,
+      epicId,
+    );
+    return transformToDto(EpicDto, epic);
+  }
+
+  @Delete(':epicId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async delete(
+    @CurrentUserId() _: string,
+    @Param() { projectId }: ProjectIdParams,
+    @Param() { epicId }: EpicIdParams,
+  ): Promise<void> {
+    await this.epicService.deleteEpic(projectId, epicId);
+  }
+}

--- a/src/epics/epics.entity.ts
+++ b/src/epics/epics.entity.ts
@@ -1,0 +1,83 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToMany,
+} from 'typeorm';
+import { Project } from 'src/projects/project.entity';
+import { User } from 'src/users/users.entity';
+import { Task } from 'src/tasks/task.entity';
+import { EpicStatus } from './enums/epic-status.enum';
+import { EpicPriority } from './enums/epic-priority.enum';
+
+@Entity('epics')
+export class Epic {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Project, (project) => project.epics, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'projectId' })
+  project!: Project;
+
+  @Column({ type: 'uuid' })
+  projectId!: string;
+
+  @OneToMany(() => Task, (task) => task.epic)
+  tasks?: Task[];
+
+  @Column({ type: 'varchar', length: 255 })
+  name!: string;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column({
+    type: 'enum',
+    enum: EpicStatus,
+    default: EpicStatus.TODO,
+  })
+  status!: EpicStatus;
+
+  @Column({
+    type: 'enum',
+    enum: EpicPriority,
+    default: EpicPriority.MEDIUM,
+  })
+  priority!: EpicPriority;
+
+  @Column({ type: 'date', nullable: true })
+  startDate?: Date;
+
+  @Column({ type: 'date', nullable: true })
+  dueDate?: Date;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'createdById' })
+  createdBy!: User;
+
+  @Column({ type: 'uuid' })
+  createdById!: string;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'ownerId' })
+  owner?: User;
+
+  @Column({ type: 'uuid', nullable: true })
+  ownerId?: string;
+
+  @Column({ type: 'boolean', default: false })
+  archived!: boolean;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  color?: string;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt!: Date;
+}

--- a/src/epics/epics.module.ts
+++ b/src/epics/epics.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { EpicService } from './epics.service';
+import { EpicController } from './epics.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Epic } from './epics.entity';
+import { Project } from 'src/projects/project.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Epic, Project])],
+  providers: [EpicService],
+  controllers: [EpicController],
+})
+export class EpicModule {}

--- a/src/epics/epics.service.ts
+++ b/src/epics/epics.service.ts
@@ -1,0 +1,85 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Epic } from './epics.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CreateEpicDto } from './dtos/create-epic.dto';
+import { UpdateEpicDto } from './dtos/update-epic.dto';
+import { Project } from 'src/projects/project.entity';
+
+@Injectable()
+export class EpicService {
+  constructor(
+    @InjectRepository(Epic)
+    private readonly epicRepo: Repository<Epic>,
+    @InjectRepository(Project)
+    private readonly projectRepo: Repository<Project>,
+  ) {}
+  async getAllEpics(projectId: string): Promise<Epic[]> {
+    return this.epicRepo.find({
+      where: { projectId: projectId },
+    });
+  }
+
+  async getOneEpic(projectId: string, epicId: string): Promise<Epic> {
+    const epic = await this.epicRepo.findOne({
+      where: { id: epicId, projectId },
+      relations: ['tasks'],
+    });
+    if (!epic) {
+      throw new NotFoundException(`Epic with id ${epicId} not found.`);
+    }
+    return epic;
+  }
+
+  async createEpic(
+    userId: string,
+    projectId: string,
+    createEpicDto: CreateEpicDto,
+  ): Promise<Epic> {
+    const project = await this.projectRepo.findOneBy({ id: projectId });
+    if (!project) {
+      throw new NotFoundException(`Project with ID ${projectId} not found.`);
+    }
+    const epicToSave = this.epicRepo.create({
+      ...createEpicDto,
+      projectId,
+      createdById: userId,
+    });
+    const epic = await this.epicRepo.save(epicToSave);
+    return epic;
+  }
+
+  async updateEpic(
+    updateEpicDto: UpdateEpicDto,
+    projectId: string,
+    epicId: string,
+  ): Promise<Epic> {
+    const epic = await this.epicRepo.findOneBy({ id: epicId, projectId });
+    if (!epic) {
+      throw new NotFoundException(`Epic with id ${epicId} not found.`);
+    }
+    if (epic.archived && updateEpicDto.archived !== false) {
+      throw new BadRequestException('Cannot modify an archived epic.');
+    }
+    const epicToSave = Object.assign(epic, updateEpicDto) as Epic;
+    const updatedEpic = await this.epicRepo.save(epicToSave);
+    return updatedEpic;
+  }
+
+  async deleteEpic(projectId: string, epicId: string): Promise<void> {
+    const epic = await this.epicRepo.findOneBy({ id: epicId, projectId });
+    if (epic?.archived)
+      throw new BadRequestException('Cannot delete an archived epic.');
+
+    const res = await this.epicRepo.delete({ id: epicId, projectId });
+    if (res.affected === 0) {
+      throw new NotFoundException(
+        `Epic with id ${epicId} not found in project ${projectId}.`,
+      );
+    }
+  }
+}

--- a/src/project-permissions/dtos/resource.dto.ts
+++ b/src/project-permissions/dtos/resource.dto.ts
@@ -16,6 +16,11 @@ export class ResourceDto {
   @IsOptional()
   @ValidateNested()
   @Type(() => ActionDto)
+  epics?: ActionDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ActionDto)
   'project-users'?: ActionDto;
 
   @IsOptional()

--- a/src/project-permissions/enums/resource.enum.ts
+++ b/src/project-permissions/enums/resource.enum.ts
@@ -3,5 +3,6 @@ export enum Resource {
   INVITE = 'invite',
   PROJECT_USER = 'project-users',
   TASK = 'tasks',
+  EPIC = 'epics',
   PROJECT_PERMISSIONS = 'project-permissions',
 }

--- a/src/projects/project.entity.ts
+++ b/src/projects/project.entity.ts
@@ -13,6 +13,7 @@ import {
 } from 'typeorm';
 import { UserDto } from '../users/dtos/user.dto';
 import { ProjectPermission } from '../project-permissions/project-permissions.entity';
+import { Epic } from 'src/epics/epics.entity';
 
 @Exclude()
 @Entity()
@@ -20,31 +21,43 @@ export class Project {
   @PrimaryGeneratedColumn('uuid')
   @Expose()
   id!: string;
+
   @Column()
   @Expose()
   name!: string;
+
   @Column()
   @Expose()
   description?: string;
+
   @Expose()
   @ManyToOne(() => User, (user) => user.projects, {
     nullable: false,
   })
   user!: UserDto;
+
   @Expose()
   @OneToMany(() => ProjectUser, (projectUsers) => projectUsers.project)
   projectUsers!: ProjectUser[];
+
+  @Expose()
+  @OneToMany(() => Epic, (epic) => epic.project)
+  epics?: Epic[];
+
   @Expose()
   @OneToMany(() => Task, (task) => task.project)
   tasks?: Task[];
+
   @Expose()
   @OneToMany(
     () => ProjectPermission,
     (projectPermission) => projectPermission.project,
   )
   permissions?: ProjectPermission[];
+
   @CreateDateColumn()
   createdAt!: Date;
+
   @UpdateDateColumn()
   updatedAt!: Date;
 }

--- a/src/projects/projects-creation.service.ts
+++ b/src/projects/projects-creation.service.ts
@@ -2,7 +2,6 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { TasksService } from 'src/tasks/tasks.service';
 import { ProjectsService } from './projects.service';
 import { CreateProjectDto } from './dtos/create-project.dto';
-import { UpdateProjectWithTasks } from './dtos/update-project.dto';
 import { Project } from './project.entity';
 import { ProjectUsersService } from 'src/project-users/project-users.service';
 import { ProjectRole } from 'src/project-users/project-role.enum';
@@ -43,27 +42,27 @@ export class ProjectCreationService {
     return project;
   }
 
-  async createProjectWithTasks(
-    createProjectDto: CreateProjectDto,
-    userId: string,
-  ) {
-    const project = await this.create(createProjectDto, userId);
-    await Promise.all(
-      createProjectDto.tasks!.map((task) =>
-        this.tasksService.create({ ...task }, userId, project.id),
-      ),
-    );
-    return await this.projectsService.getOneById(project.id);
-  }
+  // async createProjectWithTasks(
+  //   createProjectDto: CreateProjectDto,
+  //   userId: string,
+  // ) {
+  //   const project = await this.create(createProjectDto, userId);
+  //   await Promise.all(
+  //     createProjectDto.tasks!.map((task) =>
+  //       this.tasksService.create({ ...task }, userId, project.id),
+  //     ),
+  //   );
+  //   return await this.projectsService.getOneById(project.id);
+  // }
 
-  async updateProjectWithTasks(
-    project: Project,
-    updateProject: UpdateProjectWithTasks,
-  ): Promise<Project> {
-    const tasksToUpdate = updateProject.tasks!;
-    for (const taskToUpdate of tasksToUpdate) {
-      await this.tasksService.updateTaskById(taskToUpdate);
-    }
-    return this.projectsService.update(project, updateProject);
-  }
+  // async updateProjectWithTasks(
+  //   project: Project,
+  //   updateProject: UpdateProjectWithTasks,
+  // ): Promise<Project> {
+  //   const tasksToUpdate = updateProject.tasks!;
+  //   for (const taskToUpdate of tasksToUpdate) {
+  //     await this.tasksService.updateTaskById(taskToUpdate);
+  //   }
+  //   return this.projectsService.update(project, updateProject);
+  // }
 }

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -39,14 +39,14 @@ export class ProjectsController {
     @CurrentUserId() userId: string,
     @Body() createProjectDto: CreateProjectDto,
   ): Promise<ProjectDto | null> {
-    if (createProjectDto.tasks) {
-      const projectWithTasks =
-        await this.projectCreationService.createProjectWithTasks(
-          createProjectDto,
-          userId,
-        );
-      return transformToDto(ProjectDto, projectWithTasks);
-    }
+    // if (createProjectDto.tasks) {
+    //   const projectWithTasks =
+    //     await this.projectCreationService.createProjectWithTasks(
+    //       createProjectDto,
+    //       userId,
+    //     );
+    //   return transformToDto(ProjectDto, projectWithTasks);
+    // }
     const project = await this.projectCreationService.create(
       createProjectDto,
       userId,
@@ -76,14 +76,14 @@ export class ProjectsController {
     @Body() updateProjectDto: UpdateProjectWithTasks,
   ) {
     const project = await this.findOneOrFail(projectId);
-    if (updateProjectDto.tasks) {
-      const updateProjectTasks =
-        await this.projectCreationService.updateProjectWithTasks(
-          project,
-          updateProjectDto,
-        );
-      return transformToDto(ProjectDto, updateProjectTasks);
-    }
+    // if (updateProjectDto.tasks) {
+    //   const updateProjectTasks =
+    //     await this.projectCreationService.updateProjectWithTasks(
+    //       project,
+    //       updateProjectDto,
+    //     );
+    //   return transformToDto(ProjectDto, updateProjectTasks);
+    // }
     const updatedProject = await this.projectService.update(
       project,
       updateProjectDto,

--- a/src/tasks/dtos/task.dto.ts
+++ b/src/tasks/dtos/task.dto.ts
@@ -32,6 +32,9 @@ export class TaskDto {
   layer!: number;
 
   @Expose()
+  epicId!: string;
+
+  @Expose()
   dueDate!: Date;
 
   @Expose()

--- a/src/tasks/task.entity.ts
+++ b/src/tasks/task.entity.ts
@@ -14,6 +14,7 @@ import { User } from '../users/users.entity';
 import { TaskLabel } from './task-label.entity';
 import { Exclude, Expose } from 'class-transformer';
 import { Project } from '../projects/project.entity';
+import { Epic } from 'src/epics/epics.entity';
 
 @Entity()
 @Exclude()
@@ -21,6 +22,7 @@ export class Task {
   @Expose()
   @PrimaryGeneratedColumn('uuid')
   id!: string;
+
   @Column({
     type: 'varchar',
     length: 50,
@@ -28,12 +30,14 @@ export class Task {
   })
   @Expose()
   title!: string;
+
   @Column({
     type: 'text',
     nullable: false,
   })
   @Expose()
   description!: string;
+
   @Column({
     type: 'enum',
     enum: TaskStatus,
@@ -89,6 +93,14 @@ export class Task {
   @JoinColumn({ name: 'assignedToId' })
   @Expose()
   assignedTo?: User;
+
+  @ManyToOne(() => Epic, (epic) => epic.tasks, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'epicId' })
+  epic!: Epic;
+
+  @Column({ type: 'uuid' })
+  @Expose()
+  epicId!: string;
 
   @Column({ nullable: true })
   @Expose()

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -6,9 +6,13 @@ import { Task } from './task.entity';
 import { UsersModule } from 'src/users/users.module';
 import { User } from 'src/users/users.entity';
 import { TaskLabel } from './task-label.entity';
+import { Epic } from 'src/epics/epics.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Task, User, TaskLabel]), UsersModule],
+  imports: [
+    TypeOrmModule.forFeature([Task, User, Epic, TaskLabel]),
+    UsersModule,
+  ],
   controllers: [TasksController],
   providers: [TasksService],
   exports: [TasksService],

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -19,6 +19,7 @@ import { UpdateEmbeddedTaskDto } from './dtos/update-embedded-task.dto';
 import { buildTaskTree } from './utils/build-task-tree';
 import { plainToInstance } from 'class-transformer';
 import { TaskDto } from './dtos/task.dto';
+import { Epic } from 'src/epics/epics.entity';
 
 @Injectable()
 export class TasksService {
@@ -27,6 +28,8 @@ export class TasksService {
     private taskRepository: Repository<Task>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    @InjectRepository(Epic)
+    private epicRepository: Repository<Epic>,
     @InjectRepository(TaskLabel)
     private labelRepository: Repository<TaskLabel>,
   ) {}
@@ -34,25 +37,29 @@ export class TasksService {
   public async getAll(
     filters: FindTaskParams,
     pagination: PaginationParams,
-    projectId: string,
+    epicId: string,
   ): Promise<[TaskDto[], number]> {
     const queryBuilder = this.taskRepository
       .createQueryBuilder('task')
       .leftJoinAndSelect('task.user', 'user')
       .leftJoinAndSelect('task.labels', 'labels')
-      .where(`task.project.id = :projectId`, { projectId });
+      .where(`task.epicId = :epicId`, { epicId });
+
     if (filters.status) {
       queryBuilder.andWhere('task.status = :status', {
         status: filters.status,
       });
     }
+
     const search = filters.search?.trim();
+
     if (search) {
       queryBuilder.andWhere(
         '(task.title ILIKE :search OR task.description ILIKE :search)',
         { search: `%${search}%` },
       );
     }
+
     if (filters.labels?.length) {
       const subQuery = queryBuilder
         .subQuery()
@@ -73,13 +80,17 @@ export class TasksService {
     const dtos = plainToInstance(TaskDto, flatTasks, {
       excludeExtraneousValues: true,
     });
+
     const tree = buildTaskTree(dtos);
     return [tree, total];
   }
 
-  public async getOneTask(id: string): Promise<Task | null> {
+  public async getOneTask(
+    epicId: string,
+    taskId: string,
+  ): Promise<Task | null> {
     return await this.taskRepository.findOne({
-      where: { id },
+      where: { epicId, id: taskId },
       relations: ['labels', 'user', 'subtasks', 'subtasks.labels'],
     });
   }
@@ -88,14 +99,25 @@ export class TasksService {
     createTaskDto: CreateTaskDto,
     userId: string,
     projectId: string,
+    epicId: string,
   ): Promise<Task> {
+    const epic = await this.epicRepository.findOneBy({ id: epicId });
+    if (!epic) throw new NotFoundException('Epic not found');
+
+    if (epic.archived) {
+      throw new BadRequestException('Cannot create tasks on an archived epic.');
+    }
+
     const user = await this.userRepository.findOneBy({
       id: userId,
     });
+
     if (!user) throw new NotFoundException('User not found');
+
     if (createTaskDto.labels) {
       createTaskDto.labels = this.uniqueLabels(createTaskDto.labels);
     }
+
     const labels = createTaskDto.labels?.map((label) =>
       this.labelRepository.create({ name: label.name }),
     );
@@ -106,7 +128,8 @@ export class TasksService {
       status: createTaskDto.status,
       userId: userId,
       labels: labels,
-      projectId: projectId,
+      epicId,
+      projectId,
     });
 
     const task: Task = await this.taskRepository.save(newTask);
@@ -118,11 +141,26 @@ export class TasksService {
     createTaskDto: CreateTaskDto,
     userId: string,
     projectId: string,
+    epicId: string,
   ): Promise<Task> {
+    const epic = await this.epicRepository.findOneBy({ id: epicId });
+    if (!epic) throw new NotFoundException('Epic not found');
+
+    if (epic.archived) {
+      throw new BadRequestException(
+        'Cannot create subtasks on an archived epic.',
+      );
+    }
+
     const parentTask = await this.taskRepository.findOne({
       where: { id: parentId },
     });
+
     if (!parentTask) throw new NotFoundException('Parent task not found');
+
+    if (parentTask.epicId !== epicId) {
+      throw new BadRequestException('Parent task does not belong to this Epic');
+    }
 
     if (parentTask.layer >= 2) {
       throw new BadRequestException('Max task depth (3 levels) reached');
@@ -145,6 +183,7 @@ export class TasksService {
       status: createTaskDto.status || TaskStatus.OPEN,
       userId,
       labels,
+      epicId,
       projectId,
       parentId: parentTask.id,
       layer: parentTask.layer + 1,
@@ -156,6 +195,11 @@ export class TasksService {
   public async assignTask(taskId: string, userId: string): Promise<Task> {
     const task = await this.taskRepository.findOne({ where: { id: taskId } });
     if (!task) throw new NotFoundException('Task not found');
+
+    const epic = await this.epicRepository.findOneBy({ id: task.epicId });
+
+    if (epic?.archived)
+      throw new BadRequestException('Cannot assign tasks in an archived epic.');
 
     const user = await this.userRepository.findOneBy({ id: userId });
     if (!user) throw new NotFoundException('User not found');
@@ -181,9 +225,20 @@ export class TasksService {
     return await this.taskRepository.save(task);
   }
 
-  public async updateTaskById(updateDto: UpdateEmbeddedTaskDto): Promise<Task> {
-    const task = await this.getOneTask(updateDto.id);
+  public async updateTaskById(
+    epicId: string,
+    updateDto: UpdateEmbeddedTaskDto,
+  ): Promise<Task> {
+    const epic = await this.epicRepository.findOneBy({ id: epicId });
+    if (!epic) throw new NotFoundException('Epic not found');
+
+    if (epic.archived) {
+      throw new BadRequestException('Cannot update tasks in an archived epic.');
+    }
+
+    const task = await this.getOneTask(epicId, updateDto.id);
     if (!task) throw new NotFoundException('Task not found!');
+
     if (
       updateDto.status &&
       !this.isValidStatusTransition(task.status, updateDto.status)
@@ -200,16 +255,33 @@ export class TasksService {
   }
 
   public async delete(task: Task): Promise<void> {
+    const epic = await this.epicRepository.findOneBy({ id: task.epicId });
+
+    if (epic?.archived) {
+      throw new BadRequestException(
+        'Cannot delete tasks belonging to an archived epic.',
+      );
+    }
     await this.taskRepository.delete(task.id);
   }
 
   public async addLabels(
+    epicId: string,
     taskId: string,
     labelDto: CreateTaskLabelDto[],
   ): Promise<Task> {
-    const task = await this.getOneTask(taskId);
+    const task = await this.getOneTask(epicId, taskId);
     if (!task) throw new NotFoundException('Task not found');
+
+    const epic = await this.epicRepository.findOneBy({ id: epicId });
+    if (epic?.archived) {
+      throw new BadRequestException(
+        'Cannot modify labels on an archived epic.',
+      );
+    }
+
     const existingLabelNames = new Set(task.labels!.map((label) => label.name));
+
     const labels = this.uniqueLabels(labelDto)
       .filter((dto) => !existingLabelNames.has(dto.name))
       .map((label) => this.labelRepository.create({ ...label, task }));
@@ -222,16 +294,24 @@ export class TasksService {
   }
 
   public async removeLabel(
+    epicId: string,
     taskId: string,
     labelIds: string[],
-  ): Promise<Task | null> {
-    const task = await this.getOneTask(taskId);
+  ): Promise<void> {
+    const task = await this.getOneTask(epicId, taskId);
     if (!task) throw new NotFoundException('Task not found');
+
+    const epic = await this.epicRepository.findOneBy({ id: epicId });
+    if (epic?.archived) {
+      throw new BadRequestException(
+        'Cannot modify labels on an archived epic.',
+      );
+    }
+
     await this.labelRepository.delete({
       id: In(labelIds),
       taskId,
     });
-    return this.getOneTask(taskId);
   }
 
   private isValidStatusTransition(

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -1,4 +1,4 @@
-import { Expose } from 'class-transformer';
+import { Exclude, Expose } from 'class-transformer';
 import { Task } from '../tasks/task.entity';
 import {
   Column,
@@ -13,6 +13,7 @@ import { Project } from '../projects/project.entity';
 import { ProjectUser } from '../project-users/project-user.entity';
 
 @Entity()
+@Exclude()
 export class User {
   @PrimaryGeneratedColumn('uuid')
   @Expose()

--- a/test/dummy-variables/dummy-variables.ts
+++ b/test/dummy-variables/dummy-variables.ts
@@ -1,3 +1,6 @@
+import { CreateEpicDto } from 'src/epics/dtos/create-epic.dto';
+import { EpicPriority } from 'src/epics/enums/epic-priority.enum';
+import { EpicStatus } from 'src/epics/enums/epic-status.enum';
 import { CreateTaskDto } from 'src/tasks/dtos/create-task.dto';
 import { TaskStatus } from 'src/tasks/task-status.enum';
 import { CreateUserDto } from 'src/users/dtos/create-user.dto';
@@ -67,5 +70,42 @@ export const dummyProjects = [
   {
     name: 'test3',
     description: 'test description3',
+  },
+];
+
+export const dummyEpics: CreateEpicDto[] = [
+  {
+    name: 'Set up Deployment Pipeline for Feature X',
+    priority: EpicPriority.HIGH,
+  },
+  {
+    name: 'Complete Full Security Audit and Patching',
+    description:
+      'Review third-party library dependencies and apply security updates. Document findings.',
+    status: EpicStatus.IN_PROGRESS,
+    priority: EpicPriority.HIGH,
+    startDate: new Date('2025-10-20'),
+    dueDate: new Date('2025-11-05'),
+    archived: false,
+    color: '#FF0000',
+  },
+  {
+    name: 'Refactor old Task Resolver Endpoints',
+    description:
+      'Standardize error handling and remove deprecated fields from the GraphQL layer.',
+    status: EpicStatus.TODO,
+    priority: EpicPriority.MEDIUM,
+    startDate: new Date('2026-01-01'),
+    dueDate: new Date('2026-02-01'),
+    ownerId: 'b9c8d7e6-f5g4-3210-9876-54321fedcba0',
+    archived: false,
+  },
+  {
+    name: 'Initial Database Schema Design',
+    priority: EpicPriority.LOW,
+    status: EpicStatus.DONE,
+    description: 'Finalized relationships and indexing for the core entities.',
+    archived: true,
+    color: '#6c757d', // Grey for archived
   },
 ];

--- a/test/graphql/project-users.integration-spec.ts
+++ b/test/graphql/project-users.integration-spec.ts
@@ -38,9 +38,12 @@ describe('Project user Integration (GraphQL)', () => {
   let anotherUserId: string;
   let permissionAccessToken: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     testSetup = await TestSetup.create(AppModule);
     server = testSetup.app.getHttpServer() as Http2Server;
+  });
+
+  beforeEach(async () => {
     accessToken = await registerAndLogin(server, defaultUser);
     const project = await createProject(server, accessToken, {
       ...dummyProjects[0],

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -9,18 +9,17 @@ import { PasswordService } from 'src/users/password/password.service';
 import { User } from 'src/users/users.entity';
 import { INestApplication } from '@nestjs/common';
 import {
-  CreateTaskResponse,
   GraphQLErrorResponse,
   GraphQLResponse,
   HttpErrorResponse,
   LoginResponse,
 } from 'test/types/test.types';
 import { CreateTaskDto } from 'src/tasks/dtos/create-task.dto';
-import { Task } from 'src/tasks/task.entity';
 import { CreateProjectDto } from 'src/projects/dtos/create-project.dto';
 import { CreateProjectUserInput } from 'src/project-users/dtos/create-project-user.dto';
 import { ProjectUserDto } from 'src/project-users/dtos/project-user.dto';
 import { z } from 'zod';
+import { CreateEpicDto } from 'src/epics/dtos/create-epic.dto';
 
 export const registerUser = (
   server: Http2Server,
@@ -63,18 +62,14 @@ export const registerAndLogin = async (
 
 export const createTask = async (
   server: Http2Server,
-  user: CreateUserDto,
+  accessToken: string,
   task: CreateTaskDto,
   baseUrl: string,
-  noReturn?: string,
-): Promise<CreateTaskResponse | void> => {
-  const token = await registerAndLogin(server, user);
-  const response: { body: Task } = await request(server)
+) => {
+  return request(server)
     .post(`${baseUrl}/tasks`)
-    .set('Authorization', `Bearer ${token}`)
-    .send(task)
-    .expect(201);
-  if (!noReturn) return { data: response.body, token };
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send(task);
 };
 
 export const parseErrorText = (
@@ -84,6 +79,18 @@ export const parseErrorText = (
     const errorBody = JSON.parse(res.error.text) as HttpErrorResponse;
     return errorBody;
   }
+};
+
+export const createEpic = (
+  server: Http2Server,
+  token: string,
+  epic: CreateEpicDto,
+  baseUrl: string,
+): Test => {
+  return request(server)
+    .post(`${baseUrl}/epics`)
+    .set('Authorization', `Bearer ${token}`)
+    .send(epic);
 };
 
 export const createProject = (

--- a/test/rest/auth.integration-spec.ts
+++ b/test/rest/auth.integration-spec.ts
@@ -21,7 +21,7 @@ describe('Auth Integration', () => {
   let testSetup: TestSetup;
   let server: Http2Server;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     testSetup = await TestSetup.create(AppModule);
     server = testSetup.app.getHttpServer() as Http2Server;
   });
@@ -46,6 +46,7 @@ describe('Auth Integration', () => {
           expect(res.body).not.toHaveProperty('password');
         });
     });
+
     it('/users/register (POST), failed registration, duplicate email', async () => {
       await registerUser(server, defaultUser);
       return request(server)
@@ -53,6 +54,7 @@ describe('Auth Integration', () => {
         .send(defaultUser)
         .expect(409);
     });
+
     it('/users/register (POST), should hash the password before saving to the DB', async () => {
       await registerUser(server, defaultUser);
       const { dataSource } = testSetup;
@@ -67,6 +69,7 @@ describe('Auth Integration', () => {
       );
       expect(isMatch).toBe(true);
     });
+
     it('/users/register (POST), should fail with missing email', async () => {
       const invalidUser = { ...defaultUser, email: '' };
       await request(server)
@@ -86,6 +89,7 @@ describe('Auth Integration', () => {
           expect(res.body.accessToken).toMatch(/^[A-Za-z0-9-._~+/]+=*$/);
         });
     });
+
     it('/auth/login (POST), failed login, empty password', async () => {
       await registerUser(server, defaultUser);
       return loginUser(server, { ...defaultUser, password: '' })
@@ -95,6 +99,7 @@ describe('Auth Integration', () => {
           expect(errorBody?.message).toContain('password should not be empty');
         });
     });
+
     it('/auth/login (POST), failed login, not an email format', async () => {
       await registerUser(server, defaultUser);
       return loginUser(server, { ...defaultUser, email: 'adonisgmail.com' })
@@ -104,6 +109,7 @@ describe('Auth Integration', () => {
           expect(errorBody?.message).toContain('email must be an email');
         });
     });
+
     it('/auth/login (POST), failed login, unautherized, email does not exist', async () => {
       await registerUser(server, defaultUser);
       return loginUser(server, { ...defaultUser, email: 'adonis@gmail.com' })
@@ -115,6 +121,7 @@ describe('Auth Integration', () => {
           );
         });
     });
+
     it('/auth/login (POST), failed login, password does not match', async () => {
       await registerUser(server, defaultUser);
       return loginUser(server, { ...defaultUser, password: 'adonis' })
@@ -144,6 +151,7 @@ describe('Auth Integration', () => {
           expect(res.body).not.toHaveProperty('password');
         });
     });
+
     it('auth/profile (GET), failed access through auth guard', async () => {
       const incorrectToken = 'asödlfklöökasdfjsdflök';
       return request(server)
@@ -151,6 +159,7 @@ describe('Auth Integration', () => {
         .set('Authorization', `Bearer ${incorrectToken}`)
         .expect(401);
     });
+
     it('should check JWT payload data and include user role in response', async () => {
       await createUserWithRole(testSetup.app, defaultUser, [Role.ADMIN]);
       const response = await loginUser(server, defaultUser);
@@ -163,6 +172,7 @@ describe('Auth Integration', () => {
       expect(jwtData.password).not.toBeDefined();
       expect(jwtData.email).not.toBeDefined();
     });
+
     it('/auth/admin role guard should protect route (GET), successful access', async () => {
       await createUserWithRole(testSetup.app, defaultUser, [Role.ADMIN]);
       const response = await loginUser(server, defaultUser);
@@ -175,6 +185,7 @@ describe('Auth Integration', () => {
           expect(res.body.message).toBe('This is for admin only!');
         });
     });
+
     it('/auth/admin role guard should protect route (GET), access denied, role not defined', async () => {
       await registerUser(server, defaultUser);
       const response = await loginUser(server, defaultUser);
@@ -184,6 +195,7 @@ describe('Auth Integration', () => {
         .set('Authorization', `Bearer ${token}`)
         .expect(403);
     });
+
     it('/users/register (POST), should not allow to register as admin, should stripe roles and return default user', async () => {
       return await request(server)
         .post('/users/register')

--- a/test/rest/epic.integration-spec.ts
+++ b/test/rest/epic.integration-spec.ts
@@ -1,0 +1,397 @@
+import { AppModule } from 'src/app.module';
+import { TestSetup } from '../test.setup';
+import * as request from 'supertest';
+import { Http2Server } from 'http2';
+import {
+  defaultUser,
+  dummyProjects,
+  dummyEpics,
+  unauthorizedUser,
+  dummyTasks,
+  secondUser,
+} from '../dummy-variables/dummy-variables';
+import {
+  registerAndLogin,
+  createProject,
+  createEpic,
+  createTask,
+} from '../helpers/test-helpers';
+import { ProjectDto } from 'src/projects/dtos/project.dto';
+import { JwtService } from '@nestjs/jwt';
+import { JwtPayload } from 'jsonwebtoken';
+import { EpicDto } from 'src/epics/dtos/epic.dto';
+import { HttpErrorResponse } from 'test/types/test.types';
+import { randomUUID } from 'crypto';
+import { EpicPriority } from 'src/epics/enums/epic-priority.enum';
+import { EpicStatus } from 'src/epics/enums/epic-status.enum';
+import { TaskDto } from 'src/tasks/dtos/task.dto';
+import { ProjectUser } from 'src/project-users/project-user.entity';
+import { ProjectRole } from 'src/project-users/project-role.enum';
+
+describe('Epics Integration', () => {
+  let testSetup: TestSetup;
+  let accessToken: string;
+  let server: Http2Server;
+  let baseUrl: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    testSetup = await TestSetup.create(AppModule);
+    server = testSetup.app.getHttpServer() as Http2Server;
+  });
+
+  beforeEach(async () => {
+    const token = await registerAndLogin(server, { ...defaultUser });
+    const project = await createProject(server, token, {
+      ...dummyProjects[0],
+    });
+    const projectBody = project.body as ProjectDto;
+    projectId = projectBody.id;
+
+    baseUrl = `/projects/${projectBody.id}`;
+    accessToken = token;
+  });
+
+  afterEach(async () => {
+    await testSetup.cleanup();
+  });
+
+  afterAll(async () => {
+    await testSetup.teardown();
+  });
+
+  it('/epics (POST), should create an epic', async () => {
+    const res = await request(server)
+      .post(`${baseUrl}/epics`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ ...dummyEpics[0] })
+      .expect(201);
+    const body = res.body as EpicDto;
+    expect(body.name).toBe(dummyEpics[0].name);
+    expect(body.priority).toBe(dummyEpics[0].priority);
+  });
+
+  it('/epics (POST), should throw Bad Request (400), test global validation pipe', async () => {
+    const epicWithoutName = {
+      priority: EpicPriority.HIGH,
+    };
+    const res = await request(server)
+      .post(`${baseUrl}/epics`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(epicWithoutName)
+      .expect(400);
+    const body = res.body as HttpErrorResponse;
+    expect(body.message).toContain(
+      'name must be a string, name should not be empty',
+    );
+  });
+
+  it('/epics (POST), should set default values Epic', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      { name: 'test name' },
+      baseUrl,
+    );
+    const epic = epicData.body as EpicDto;
+    expect(epic.priority).toBe(EpicPriority.MEDIUM);
+    expect(epic.status).toBe(EpicStatus.TODO);
+    expect(epic.archived).toBe(false);
+  });
+
+  it('/epics (POST), permission guard should block post of unknown project user, 401 Unauthorized', async () => {
+    const token = await registerAndLogin(server, unauthorizedUser);
+    const epicData = await createEpic(server, token, dummyEpics[1], baseUrl);
+    const body = epicData.body as HttpErrorResponse;
+    expect(body.statusCode).toBe(401);
+    expect(body.message).toContain('User is not part of project.');
+  });
+
+  it('/epics/epicId (GET),should get one epic', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      dummyEpics[1],
+      baseUrl,
+    );
+
+    const epic = epicData.body as EpicDto;
+
+    const res = await request(server)
+      .get(`${baseUrl}/epics/${epic.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    const body = res.body as EpicDto;
+
+    expect(body.name).toContain(dummyEpics[1].name);
+    expect(body.priority).toBe(dummyEpics[1].priority);
+  });
+
+  it('/epics/epicId (GET), should throw Not Found (404), accessing epic with wrong projectId', async () => {
+    const projectData = await createProject(
+      server,
+      accessToken,
+      dummyProjects[1],
+    );
+    const project = projectData.body as ProjectDto;
+    const projectId = project.id;
+
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      dummyEpics[0],
+      baseUrl,
+    );
+    const epic = epicData.body as EpicDto;
+    const epicId = epic.id;
+
+    await request(server)
+      .get(`/projects/${projectId}/epics/${epicId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
+  });
+
+  it('/epics/epicId (GET), should throw Not Fround (404), epic not found', async () => {
+    const wrongEpicId = randomUUID();
+    const res = await request(server)
+      .get(`${baseUrl}/epics/${wrongEpicId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
+    const body = res.body as HttpErrorResponse;
+    expect(body.message).toContain(`Epic with id ${wrongEpicId} not found.`);
+  });
+
+  it('/epics (GET), should return all epics', async () => {
+    await createEpic(server, accessToken, dummyEpics[0], baseUrl);
+    await createEpic(server, accessToken, dummyEpics[1], baseUrl);
+
+    const res = await request(server)
+      .get(`${baseUrl}/epics`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    const body = res.body as EpicDto[];
+
+    expect(body.length).toEqual(2);
+    expect(body[0].name).toBe(dummyEpics[0].name);
+    expect(body[1].description).toBe(dummyEpics[1].description);
+    expect(body[1].status).toBe(dummyEpics[1].status);
+  });
+
+  it('/epics/epicId (PATCH), should update ownerId and description', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      dummyEpics[0],
+      baseUrl,
+    );
+
+    const epic = epicData.body as EpicDto;
+
+    expect(epic.ownerId).toBeNull();
+    expect(epic.description).toBeNull();
+
+    const epicId = epic.id;
+
+    const jwtData: JwtPayload = testSetup.app
+      .get(JwtService)
+      .verify(accessToken);
+
+    const ownerId = jwtData.sub;
+    const description = 'this is a test description';
+
+    const res = await request(server)
+      .patch(`${baseUrl}/epics/${epicId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ description, ownerId })
+      .expect(200);
+
+    const resBody = res.body as EpicDto;
+
+    expect(resBody.name).toBe(dummyEpics[0].name);
+    expect(resBody.ownerId).toBe(ownerId);
+    expect(resBody.description).toBe(description);
+  });
+
+  it('/epics/epicId (PATCH), should throw Bad Request (400), change on archived epic', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      { ...dummyEpics[1], archived: true },
+      baseUrl,
+    );
+    const epic = epicData.body as EpicDto;
+    const epicId = epic.id;
+
+    expect(epic.archived).toBe(true);
+
+    const newName = { name: 'changed epic name' };
+
+    const res = await request(server)
+      .patch(`${baseUrl}/epics/${epicId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(newName);
+    const body = res.body as HttpErrorResponse;
+    expect(body.statusCode).toBe(400);
+    expect(body.message).toContain('Cannot modify an archived epic.');
+  });
+
+  it('/epics/epicId (PATCH), should be able to change archived from false to true', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      { ...dummyEpics[0], archived: true },
+      baseUrl,
+    );
+    const epic = epicData.body as EpicDto;
+
+    const newName = { name: 'changed epic name' };
+
+    await request(server)
+      .patch(`${baseUrl}/epics/${epic.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(newName)
+      .expect(400);
+
+    await request(server)
+      .patch(`${baseUrl}/epics/${epic.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ archived: false })
+      .expect(200);
+
+    const res = await request(server)
+      .patch(`${baseUrl}/epics/${epic.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(newName)
+      .expect(200);
+    const body = res.body as EpicDto;
+    expect(body.name).toBe(newName.name);
+  });
+
+  it('/epics/epicId (DELETE), should delete epic', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      { ...dummyEpics[0] },
+      baseUrl,
+    );
+
+    const epic = epicData.body as EpicDto;
+
+    expect(epic.id).toBeDefined();
+
+    await request(server)
+      .delete(`${baseUrl}/epics/${epic.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(204);
+
+    await request(server)
+      .get(`${baseUrl}/epics/${epic.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
+  });
+
+  it('/epics/epicId (DELETE), should delete tasks with epic', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      dummyEpics[1],
+      baseUrl,
+    );
+    const epic = epicData.body as EpicDto;
+    const epicId = epic.id;
+
+    const res = await createTask(
+      server,
+      accessToken,
+      dummyTasks[2],
+      `${baseUrl}/epics/${epicId}`,
+    );
+
+    const taskBody = res.body as TaskDto;
+
+    const taskData = await request(server)
+      .get(`${baseUrl}/epics/${epicId}/tasks/${taskBody.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    const task = taskData.body as TaskDto;
+    expect(task.epicId).toBe(epicId);
+
+    await request(server)
+      .delete(`${baseUrl}/epics/${epicId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(204);
+
+    await request(server)
+      .get(`${baseUrl}/epics/${epicId}/tasks/${taskBody.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
+  });
+
+  it('/epics/epicId (DELETE), should not be able to delete archived epic', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      { ...dummyEpics[0], archived: true },
+      baseUrl,
+    );
+    const epic = epicData.body as EpicDto;
+
+    const res = await request(server)
+      .delete(`${baseUrl}/epics/${epic.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(400);
+    const body = res.body as HttpErrorResponse;
+    expect(body.message).toContain('Cannot delete an archived epic.');
+  });
+
+  it('resource guard, new project user of ProjectRole USER should only be able to read from epics routes', async () => {
+    const epicData = await createEpic(
+      server,
+      accessToken,
+      dummyEpics[1],
+      baseUrl,
+    );
+    const epic = epicData.body as EpicDto;
+    const epicId = epic.id;
+
+    const token = await registerAndLogin(server, secondUser);
+    const { dataSource } = testSetup;
+    const projectUserRepo = dataSource.getRepository(ProjectUser);
+    const jwtData: JwtPayload = testSetup.app.get(JwtService).verify(token);
+    const userId = jwtData.sub;
+
+    const newProjectUserData = {
+      userId,
+      projectId,
+      role: ProjectRole.USER,
+    };
+    const newProjectUser = projectUserRepo.create(newProjectUserData);
+    await projectUserRepo.save(newProjectUser);
+
+    await request(server)
+      .get(`${baseUrl}/epics/${epicId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    await request(server)
+      .get(`${baseUrl}/epics`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    await request(server)
+      .post(`${baseUrl}/epics`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(dummyEpics[2])
+      .expect(403);
+    await request(server)
+      .patch(`${baseUrl}/epics/${epicId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(dummyEpics[1])
+      .expect(403);
+    await request(server)
+      .delete(`${baseUrl}/epics/${epicId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403);
+  });
+});

--- a/test/workflows/email-verification.integration-spec.ts
+++ b/test/workflows/email-verification.integration-spec.ts
@@ -14,7 +14,7 @@ describe('Email verification workflow', () => {
   let testSetup: TestSetup;
   let server: Http2Server;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     testSetup = await TestSetup.create(AppModule);
     server = testSetup.app.getHttpServer() as Http2Server;
   });
@@ -93,6 +93,7 @@ describe('Email verification workflow', () => {
       'https://your-frontend.com/email-verification/expired-dummy',
     );
   });
+
   it('should return not found with repeated clicks on link', async () => {
     const token = await registerAndLogin(server, defaultUser);
     const jwtData: JwtPayload = testSetup.app.get(JwtService).verify(token);
@@ -117,6 +118,7 @@ describe('Email verification workflow', () => {
       'https://your-frontend.com/email-verification/not-found-dummy',
     );
   });
+
   it('should throw BAD REQUEST on invalid token fromat, test pipe', async () => {
     const emptyToken = '';
     const notUUIDToken = 'aölsdkfjö3lfj';

--- a/test/workflows/invitation.integration-spec.ts
+++ b/test/workflows/invitation.integration-spec.ts
@@ -20,7 +20,7 @@ describe('Project invitation workflow', () => {
   let testSetup: TestSetup;
   let server: Http2Server;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     testSetup = await TestSetup.create(AppModule);
     server = testSetup.app.getHttpServer() as Http2Server;
   });

--- a/test/workflows/password-reset.integration-spec.ts
+++ b/test/workflows/password-reset.integration-spec.ts
@@ -15,7 +15,7 @@ describe('Password reset workflow', () => {
   let testSetup: TestSetup;
   let server: Http2Server;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     testSetup = await TestSetup.create(AppModule);
     server = testSetup.app.getHttpServer() as Http2Server;
   });


### PR DESCRIPTION
This PR introduces the Epics resource as a new intermediate layer between Projects and Tasks (Project -> Epic -> Task), completing the core hierarchy. Additionally, it includes a crucial refactoring fix to resolve resource warnings in the test environment.

- Introduced the EpicsModule with its own Entity, DTOs, Service, and Controller. Epics are now linked to Projects, and Tasks are now linked to Epics.
- Updated Project and Task entities and modules to handle the new Epic foreign key relationships.
- Updated API routes to reflect the new structure (e.g., accessing tasks now requires the parent epic ID).
- Integrated the Epic resource into the Project Permission System (ResourceGuard) to allow role-based access control (read, create, update, delete) for Epics.

- The previous setup used beforeEach() to initialize the entire application context (TestSetup.create(AppModule)) for every single test (it() or test()) block. This excessive instantiation caused massive overhead, resource leakage, and led to the recurring MaxListenersExceededWarning and duplicate log entries (due to multiple Winston instances).
- > Refactored the application initialization to use beforeAll() in all integration test suites. This ensures the heavy setup runs only once per test file, drastically improving test execution speed, eliminating the resource overload, and resolving the duplicate logging issue.